### PR TITLE
Do not allow access to router script in production.

### DIFF
--- a/router.php
+++ b/router.php
@@ -6,6 +6,12 @@
  * your local PHP development server. NOT intended for production whatsoever.
  */
 
+if (php_sapi_name() !== 'cli-server') {
+    header('HTTP/1.1 403 Forbidden');
+    echo 'Script only accessible in development environment.';
+    exit;
+}
+
 // Allow query parameters to be appended to the request
 $requestUri = parse_url($_SERVER["REQUEST_URI"], PHP_URL_PATH);
 


### PR DESCRIPTION
Upon visiting `https://elementary.io/router`, currently (20190316) it shows:

This page isn’t working
**elementary.io** is currently unable to handle this request.
HTTP ERROR 500

If the script is only meant for use while development, then better to forbid access to it on production servers.

Fixes #

### Changes Summary

- 
- 
- 

This pull request is ready for review.
